### PR TITLE
diskcache2: add a random tag to pending filenames.

### DIFF
--- a/cachekit/diskcache2.go
+++ b/cachekit/diskcache2.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -313,7 +314,11 @@ func (cache *DiskCache2) Get(ctx context.Context, keyHash dc2Hash) []byte {
 
 func (cache *DiskCache2) Set(ctx context.Context, keyHash dc2Hash, value []byte, ttl time.Duration) {
 	path := cache.itemPath(keyHash)
-	pendingPath := path + dc2ExtPending
+
+	pendingTag := make([]byte, 4)
+	_, _ = rand.Read(pendingTag)
+
+	pendingPath := fmt.Sprintf("%v-%x%v", path, pendingTag, dc2ExtPending)
 
 	size := int64(len(value)) + dc2HeaderSize
 	var oldSize int64


### PR DESCRIPTION
This makes concurrent goroutines trying to cache the same key not attempt to write into the same pending file, which has a potential of creating truncated or corrupted cache object. Because `rename` is atomic even if it replaces an existing file this should be enough to ensure the data is always in consistent state (last write wins).